### PR TITLE
* Implement merge! like JBuilder

### DIFF
--- a/lib/turbostreamer.rb
+++ b/lib/turbostreamer.rb
@@ -1,5 +1,6 @@
 require 'stringio'
 require 'turbostreamer/key_formatter'
+require 'turbostreamer/errors'
 
 class TurboStreamer
 
@@ -160,6 +161,21 @@ class TurboStreamer
     end
   end
 
+  def merge!(hash_or_array)
+    if ::Array === hash_or_array
+      hash_or_array.each do |array_element|
+        value!(array_element)
+      end
+    elsif ::Hash === hash_or_array
+      hash_or_array.each_pair do |key, value|
+        key!(key)
+        value!(value)
+      end
+    else
+      raise Errors::MergeError.build(hash_or_array)
+    end
+  end
+
   alias_method :method_missing, :set!
   private :method_missing
 
@@ -297,7 +313,7 @@ class TurboStreamer
   # Encodes the current builder as JSON.
   def target!
     @encoder.flush
-    
+
     if @encoder.output.is_a?(::StringIO)
       @encoder.output.string
     else

--- a/lib/turbostreamer/errors.rb
+++ b/lib/turbostreamer/errors.rb
@@ -1,0 +1,12 @@
+
+
+class TurboStreamer
+  module Errors
+    class MergeError < ::StandardError
+      def self.build(updates)
+        message = "Can't merge #{updates.inspect} which isn't Hash or Array"
+        new(message)
+      end
+    end
+  end
+end

--- a/test/turbo_streamer_test.rb
+++ b/test/turbo_streamer_test.rb
@@ -5,7 +5,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
   test 'outputting a top-level primative value' do
     result = jbuild { |json| json.value! nil  }
     assert_nil result
-    
+
     [1, true, false, "string"].each do |primative|
       result = jbuild { |json| json.value! primative  }
       assert_equal primative, result
@@ -19,7 +19,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({}, result)
   end
-  
+
   test 'empty top-level array' do
     result = jbuild do |json|
       json.array!
@@ -27,13 +27,13 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal [], result
   end
-  
+
   test 'object! with single key and primative' do
     [nil, 1, true, false, "string"].each do |primative|
       result = jbuild do |json|
         json.object! { json.content primative }
       end
-      
+
       assert_equal({'content' => primative}, result)
     end
   end
@@ -48,7 +48,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'title' => 'hello', 'content' => 'world'}, result)
   end
-  
+
   test 'set a key/value in an object with set!' do
     result = jbuild do |json|
       json.object! { json.set! :each, 'stuff' }
@@ -66,8 +66,8 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'key' => true}, result)
   end
-  
-  test 'set a key with a block' do    
+
+  test 'set a key with a block' do
     result = jbuild do |json|
       json.object! do
         json.key do
@@ -81,7 +81,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
   test 'set a key to a object via pluck' do
     value = {id: 1, name: "Jon"}
-    
+
     result = jbuild do |json|
       json.object! do
         json.key value, :name
@@ -90,10 +90,10 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'key' => {'name' => 'Jon'}}, result)
   end
-  
+
   test 'set a key to an array via pluck' do
     value = [{id: 1, name: "Jon"}]
-    
+
     result = jbuild do |json|
       json.object! do
         json.key value, :name
@@ -102,10 +102,10 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'key' => [{'name' => 'Jon'}]}, result)
   end
-  
+
   test 'set a key to an array with a block' do
     value = [{id: 1, name: "Jon"}]
-    
+
     result = jbuild do |json|
       json.object! do
         json.key value do |item|
@@ -116,7 +116,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'key' => ['Jon']}, result)
   end
-  
+
   test 'pluck! on an object' do
     person = Struct.new(:name, :age).new('David', 32)
 
@@ -126,7 +126,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'name' => 'David', 'age' => 32}, result)
   end
-  
+
   test 'pluck! on an hash' do
     person = {name: 'Jim', age: 34}
 
@@ -160,12 +160,12 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'name' => 'Jim', 'age' => 34}, result)
   end
-  
+
   test 'array! with an array of primatives' do
     result = jbuild do |json|
       json.array! [nil, 1, true, false, "string"]
     end
-      
+
     assert_equal([nil, 1, true, false, "string"], result)
   end
 
@@ -180,38 +180,38 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal({'comments' => []}, result)
   end
-  
+
   test 'array! block calling child! with a collection' do
     result = jbuild do |json|
       json.array! do
         json.child! [1, 2]
       end
     end
-      
+
     assert_equal([[1, 2]], result)
   end
-  
+
   test 'array! block calling child! with a collection to pluck' do
     result = jbuild do |json|
       json.array! do
         json.child! [{id: 1, name: 'one'}, {id: 2, name: 'two'}], :name
       end
     end
-      
+
     assert_equal([[{'name' => 'one'}, {'name' => 'two'}]], result)
   end
-  
-  
+
+
   test 'array! block calling child! with a object to pluck' do
     result = jbuild do |json|
       json.array! do
         json.child!({id: 1, name: 'one'}, :name)
       end
     end
-      
+
     assert_equal([{'name' => 'one'}], result)
   end
-  
+
   test 'array! block calling child! with a collection and a block' do
     result = jbuild do |json|
       json.array! do
@@ -220,7 +220,7 @@ class TurboStreamerTest < ActiveSupport::TestCase
         end
       end
     end
-      
+
     assert_equal([[2, 4]], result)
   end
 
@@ -233,23 +233,23 @@ class TurboStreamerTest < ActiveSupport::TestCase
 
     assert_equal([{"id" => 1},{"id" => 2}], result)
   end
-  
+
   test 'array! with an array and a block' do
     result = jbuild do |json|
       json.array! [1, "string"] do |value|
         json.child! value*2
       end
     end
-      
+
     assert_equal([2, "stringstring"], result)
   end
-  
-  
+
+
   test 'array! with an array and attributes to pluck' do
     result = jbuild do |json|
       json.array! [{a: 1, b: 2}, {a: 3, b: 4}], :b
     end
-      
+
     assert_equal([{'b' => 2}, {'b' => 4}], result)
   end
 
@@ -276,6 +276,47 @@ class TurboStreamerTest < ActiveSupport::TestCase
     end
 
     assert_equal({"author" => {"name" => "David", "age" => 32}}, result)
+  end
+
+  test 'merge! a hash in an object' do
+    result = jbuild do |json|
+      json.object! do
+        json.set! :author do
+          json.object! do
+            json.merge!(
+              name: 'David',
+              age: 32,
+            )
+          end
+        end
+      end
+    end
+
+    assert_equal({"author" => {"name" => "David", "age" => 32}}, result)
+  end
+
+  test 'merge! a array in an array' do
+    result = jbuild do |json|
+      json.array! do
+        json.merge! [1, 2]
+      end
+    end
+
+    assert_equal([1, 2], result)
+  end
+
+  test 'merge! a value with unexpected class in an object' do
+    assert_raises(TurboStreamer::Errors::MergeError) do
+      jbuild do |json|
+        json.object! do
+          json.set! :author do
+            json.object! do
+              json.merge!(Set.new)
+            end
+          end
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Was migrating Jbuilder to turbostreamer, and found out `merge!` is a feature in JBuilder which is absent in turbostreamer
So I implement it without the "current value" stuff from JBuilder