### PR TITLE
[WIP] Fix encoding issue

### DIFF
--- a/ext/actionview/buffer.rb
+++ b/ext/actionview/buffer.rb
@@ -1,12 +1,17 @@
 module ActionView
   class OutputBuffer
-    alias :write :safe_concat
+    def write(val)
+      if val.respond_to?(:force_encoding)
+        val = val.dup.force_encoding(encoding)
+      end
+      safe_concat(val)
+    end
   end
-  
+
   class StreamingBuffer #:nodoc:
     alias :write :safe_concat
   end
-  
+
   class JSONStreamingBuffer #:nodoc:
     def initialize(block)
       @block = block
@@ -21,5 +26,5 @@ module ActionView
     alias :safe_concat :<<
     alias :safe_append= :<<
   end
-  
+
 end

--- a/test/turbo_streamer/integration_test.rb
+++ b/test/turbo_streamer/integration_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class TurboStreamer::IntegrationTest < ActiveSupport::TestCase
+
+  test 'support unicode string with action view output buffer' do
+    output_buffer = ::ActionView::OutputBuffer.new
+    string        = "香港"
+
+    assert_equal(::Encoding::UTF_8, output_buffer.encoding)
+    assert_equal(::Encoding::UTF_8, string.encoding)
+
+    output_buffer.safe_concat(string)
+
+    assert_equal(::Encoding::UTF_8, output_buffer.encoding)
+    assert_equal(::Encoding::UTF_8, string.encoding)
+
+    output_buffer.write(string)
+
+    assert_equal(::Encoding::UTF_8, output_buffer.encoding)
+    assert_equal(::Encoding::UTF_8, string.encoding)
+
+
+    output_buffer = ::ActionView::OutputBuffer.new
+    tstreamer = ::TurboStreamer.new(
+      output_buffer: output_buffer,
+    )
+    tstreamer.object! do
+      tstreamer.key!("some_key")
+      tstreamer.value!(string)
+    end
+
+    assert_equal(::Encoding::UTF_8, string.encoding)
+    assert_equal(::Encoding::UTF_8, output_buffer.encoding)
+  end
+
+end


### PR DESCRIPTION
I only have the test case not the fix

I was trying to cache content with Unicode
but `output_buffer.encoding` becomes `ASCII-8BIT` after `push_key`/`push_value` in encoder called (encoder is `oj` and the output is a `ActionView::OutputBuffer`