### PR TITLE
Fix double comma issue when caching enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,21 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 
 env:
   - ENCODER=oj
   - ENCODER=wankel
+
+before_install:
+  # Cannot use bundler 2.x due to dependency
+  # Solution from https://github.com/travis-ci/travis-ci/issues/5290#issuecomment-164600246
+  - gem update --system
+  - gem --version
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v '~> 1.17.0' --conservative
 
 install:
   - wget 'https://github.com/lloyd/yajl/archive/2.1.0.tar.gz'
@@ -22,3 +32,9 @@ gemfile:
   - gemfiles/rails-4.2.gemfile
   - gemfiles/rails-5.0.gemfile
   - gemfiles/rails-5.1.gemfile
+  - gemfiles/rails-5.2.gemfile
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "railties", "~> 4.2"
-gem "activesupport", "~> 4.2"
-gem "actionview", "~> 4.2"
+gem "railties", "~> 4.2.0"
+gem "activesupport", "~> 4.2.0"
+gem "actionview", "~> 4.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "railties", "~> 5.0"
-gem "activesupport", "~> 5.0"
-gem "actionview", "~> 5.0"
+gem "railties", "~> 5.0.0"
+gem "activesupport", "~> 5.0.0"
+gem "actionview", "~> 5.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "railties", "~> 5.1"
-gem "activesupport", "~> 5.1"
-gem "actionview", "~> 5.1"
+gem "railties", "~> 5.1.0"
+gem "activesupport", "~> 5.1.0"
+gem "actionview", "~> 5.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "railties", "~> 5.2.0"
+gem "activesupport", "~> 5.2.0"
+gem "actionview", "~> 5.2.0"
+
+gemspec path: "../"

--- a/lib/turbostreamer/encoders/oj.rb
+++ b/lib/turbostreamer/encoders/oj.rb
@@ -42,8 +42,6 @@ class TurboStreamer
       @stack << :map
       @indexes << 0
       if @write_comma_on_next_push
-        @stream_writer.flush
-        @output.write(",".freeze)
         @write_comma_on_next_push = false
       end
       @stream_writer.push_object
@@ -59,8 +57,6 @@ class TurboStreamer
       @stack << :array
       @indexes << 0
       if @write_comma_on_next_push
-        @stream_writer.flush
-        @output.write(",".freeze)
         @write_comma_on_next_push = false
       end
       @stream_writer.push_array

--- a/lib/turbostreamer/encoders/oj.rb
+++ b/lib/turbostreamer/encoders/oj.rb
@@ -4,7 +4,7 @@ class TurboStreamer
   class OjEncoder
 
     attr_reader :output
-    
+
     def initialize(io, options={})
       @stack = []
       @indexes = []
@@ -75,21 +75,26 @@ class TurboStreamer
     def inject(string)
       @stream_writer.flush
 
+      # It's possible to have
+      # `@write_comma_on_next_push == true` and `@indexes.last > 0`
+      # So there might be double comma written without this flag
+      comma_written = false
       if @write_comma_on_next_push
         @output.write(",".freeze)
         @write_comma_on_next_push = false
+        comma_written = true
       end
 
       if @stack.last == :array && !string.empty?
         if @indexes.last > 0
-          self.output.write(",")
+          self.output.write(",") unless comma_written
         else
           @write_comma_on_next_push = true
         end
         @indexes[-1] += 1
       elsif @stack.last == :map && !string.empty?
         if @indexes.last > 0
-          self.output.write(",")
+          self.output.write(",") unless comma_written
         else
           @write_comma_on_next_push = true
         end
@@ -130,7 +135,10 @@ class TurboStreamer
         result = result.sub(/\A\[/, ''.freeze).chomp("]".freeze)
       end
 
-      result
+      # Possible for `output.string` to have value like
+      # `[,{"key":"value"}]\n`
+      # Thus the comma must be removed here
+      result.sub(/\A,/, ''.freeze)
     ensure
       @indexes.pop
       @stream_writer = old_writer

--- a/test/turbo_streamer_template_test.rb
+++ b/test/turbo_streamer_template_test.rb
@@ -82,7 +82,7 @@ class TurboStreamerTemplateTest < ActionView::TestCase
     overrides.each do |index, value|
       assert_equal value, result[index]
     end
-    
+
     assert_equal('post body 5', result[4]['body']) unless overrides[4]
     assert_equal('Heinemeier Hansson', result[2]['author']['last_name']) unless overrides[2]
     assert_equal('Pavel', result[5]['author']['first_name']) unless overrides[5]
@@ -266,6 +266,50 @@ class TurboStreamerTemplateTest < ActionView::TestCase
     assert_equal(%w[a b c], Wankel.load(json))
   end
 
+  test 'fragment caching works in an array' do
+    undef_context_methods :cache_fragment_name
+
+    json = render_streamer <<-STREAMER
+      json.array! do
+        %w[a b c d].each do |char|
+          json.cache!("char_" + char) do
+            json.object! do
+              json.set!(:char, char)
+            end
+          end 
+        end
+      end
+    STREAMER
+
+    # cache miss output correct
+    assert_equal([
+      {"char" => "a"},
+      {"char" => "b"},
+      {"char" => "c"},
+      {"char" => "d"},
+    ], Wankel.load(json))
+
+    json = render_streamer <<-STREAMER
+      json.array! do
+        %w[a b c d].each do |char|
+          json.cache!("char_" + char) do
+            json.object! do
+              json.set!(:char, char)
+            end
+          end 
+        end
+      end
+    STREAMER
+
+    # cache hit output correct
+    assert_equal([
+      {"char" => "a"},
+      {"char" => "b"},
+      {"char" => "c"},
+      {"char" => "d"},
+    ], Wankel.load(json))
+  end
+
   test 'fragment caching works with current cache digests' do
     @context.expects(:cache_fragment_name).with('cachekey', {})
 
@@ -328,7 +372,7 @@ class TurboStreamerTemplateTest < ActionView::TestCase
     CACHE_KEY_PROC.expects(:call).returns(true)
 
     Rails.cache.write("streamer/true/1/post body 1/David Heinemeier Hansson", '"CACHE HIT"')
-    
+
     json = render_streamer <<-STREAMER
       json.cache_collection! BLOG_POST_COLLECTION, key: CACHE_KEY_PROC do |blog_post|
         json.partial! 'blog_post', :blog_post => blog_post
@@ -369,5 +413,5 @@ class TurboStreamerTemplateTest < ActionView::TestCase
 
     assert_collection_rendered(json, {0 => 'CACHE HIT'}, 'key')
   end
-  
+
 end


### PR DESCRIPTION
The issue is due to incorrect implementation:
- We write comma while `Oj::StreamWriter` writes it too in `#map_open` & `#array_open`
- We write comma twice in `#inject`

File change from #5 included for better test coverage

Fixes #8 