### PR TITLE
Oj encoder: set `buffer_size` on `StreamWriter`

### DIFF
--- a/lib/turbostreamer/encoders/oj.rb
+++ b/lib/turbostreamer/encoders/oj.rb
@@ -5,11 +5,13 @@ class TurboStreamer
 
     attr_reader :output
 
+    BUFFER_SIZE = 4096
+
     def initialize(io, options={})
       @stack = []
       @indexes = []
 
-      @options = {mode: :json}.merge(options)
+      @options = {mode: :json, buffer_size: BUFFER_SIZE}.merge(options)
 
       @output = io
       @stream_writer = ::Oj::StreamWriter.new(io, @options)


### PR DESCRIPTION
While auditing streaming responses through Unicorn I discovered that `Oj::StreamWriter`
can be initialized with a `buffer_size` which will reduce the number of `io.write` calls.
This is a big win when constructing JSON in small chunks.

This change also helps in the non-streaming case a the `io` object is a
`ActionView::OutputBuffer` which appends the chunks to a string holding the whole response.

In the `ActionView::OutputBuffer` (non-streaming clients) case I saw an improvement of ~10%.
In the `ActionView::JSONStreamingBuffer` (for streaming clients) case the improvement could be
as large as 2x faster (because `socket.write` calls add up).

To see how `buffer_size` is used in Oj see:
https://github.com/ohler55/oj/blob/master/ext/oj/stream_writer.c#L126

I chose a value of 4096 because that is the default value that `oj_str_writer_init`
is called with (which initializes the buffer size).

It would be awesome if this option was easily configurable.