### PR TITLE
StreamingTemplateRenderer: don't require layout to stream

### DIFF
--- a/ext/actionview/streaming_template_renderer.rb
+++ b/ext/actionview/streaming_template_renderer.rb
@@ -2,7 +2,8 @@ module ActionView
   class StreamingTemplateRenderer < TemplateRenderer
     
     def render_template(template, layout_name = nil, locals = {}) #:nodoc:
-      return [super] unless layout_name && template.supports_streaming?
+      template_supports_streaming = (layout_name && template.supports_streaming?) || template.handler == TurboStreamer::Handler
+      return [super] unless template_supports_streaming
 
       locals ||= {}
       layout   = layout_name && find_layout(layout_name, locals.keys, [formats.first])


### PR DESCRIPTION
It is entirely possible to call `render layout: false, stream: true`
for a TurboStreamer template. If `layout` is `false` then `render_template`
never returns a response which Unicorn can stream in chunks to the client.

As long as the template's handler is `TurboStreamer::Handler` then
we can build a streaming response.